### PR TITLE
Fix jdk 25 javafx runtime error

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ A JavaFX-based restaurant ordering and inventory management system with:
 - SQLite persistence (file `data/pos.db`)
 
 ## Prerequisites
-- Java 21+
-- Maven 3.9+
+- Java 25+
+- Maven 3.9+ (or use the `java` command shown below)
 
 ## Run
 ```bash
@@ -21,10 +21,18 @@ mvn -q javafx:run -Dexec.mainClass=com.restaurant.pos.MainApp
 
 If the JavaFX plugin has trouble on your platform, you can run:
 ```bash
-java --module-path ~/.m2/repository/org/openjfx/javafx-controls/21.0.5 --add-modules javafx.controls,javafx.fxml \
-     -cp target/pos-1.0-SNAPSHOT.jar:$(dependency:list -DincludeScope=runtime -DoutputAbsoluteArtifactFilename=true -DincludeTypes=jar -DexcludeTransitive=false -DappendOutput=false | grep ".jar" | tr '\n' ':') \
-     com.restaurant.pos.MainApp
+# If Maven isn't installed, run directly with Java 25
+JFX_VER=25.0.1
+JFX_MP=~/.m2/repository/org/openjfx/javafx-controls/${JFX_VER}
+java \
+  --enable-preview \
+  --module-path "${JFX_MP}" \
+  --add-modules javafx.controls,javafx.fxml \
+  -cp "target/pos-1.0-SNAPSHOT.jar:$(jdeps -q --print-classpath target/pos-1.0-SNAPSHOT.jar 2>/dev/null || echo ~/.m2/repository/*)" \
+  com.restaurant.pos.MainApp
 ```
+
+Note: When running with plain `java`, ensure JavaFX platform-specific classifiers are present (e.g., `linux`, `win`, `mac`, `mac-aarch64`).
 
 ## Notes
 - Database file is created at first run with seed data.

--- a/README.md
+++ b/README.md
@@ -9,30 +9,23 @@ A JavaFX-based restaurant ordering and inventory management system with:
 - Analytics with simple sales forecasting
 - SQLite persistence (file `data/pos.db`)
 
-## Prerequisites
+## Prerequisites (Windows only)
 - Java 25+
-- Maven 3.9+ (or use the `java` command shown below)
+- Maven 3.9+
 
 ## Run
-```bash
+```bat
 mvn -q -DskipTests package
 mvn -q javafx:run -Dexec.mainClass=com.restaurant.pos.MainApp
 ```
 
 If the JavaFX plugin has trouble on your platform, you can run:
-```bash
-# If Maven isn't installed, run directly with Java 25
-JFX_VER=25.0.1
-JFX_MP=~/.m2/repository/org/openjfx/javafx-controls/${JFX_VER}
-java \
-  --enable-preview \
-  --module-path "${JFX_MP}" \
-  --add-modules javafx.controls,javafx.fxml \
-  -cp "target/pos-1.0-SNAPSHOT.jar:$(jdeps -q --print-classpath target/pos-1.0-SNAPSHOT.jar 2>/dev/null || echo ~/.m2/repository/*)" \
-  com.restaurant.pos.MainApp
+```bat
+REM If you prefer running directly with Java (Windows)
+set JFX_VER=25.0.1
+set JFX_MP=%USERPROFILE%\.m2\repository\org\openjfx\javafx-controls\%JFX_VER%
+java --module-path "%JFX_MP%" --add-modules javafx.controls,javafx.fxml -cp "target\pos-1.0-SNAPSHOT.jar" com.restaurant.pos.MainApp
 ```
-
-Note: When running with plain `java`, ensure JavaFX platform-specific classifiers are present (e.g., `linux`, `win`, `mac`, `mac-aarch64`).
 
 ## Notes
 - Database file is created at first run with seed data.

--- a/pom.xml
+++ b/pom.xml
@@ -8,24 +8,41 @@
   <description>JavaFX-based restaurant ordering and inventory management system</description>
 
   <properties>
-    <maven.compiler.release>21</maven.compiler.release>
+    <maven.compiler.release>25</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <javafx.version>21.0.5</javafx.version>
+    <!-- Target the latest compatible JavaFX for JDK 25 -->
+    <javafx.version>25.0.1</javafx.version>
     <slf4j.version>2.0.13</slf4j.version>
     <sqlite.jdbc.version>3.46.0.0</sqlite.jdbc.version>
+    <!-- Resolve platform-specific JavaFX native artifacts; default for Linux x86_64 -->
+    <javafx.platform>linux</javafx.platform>
   </properties>
 
   <dependencies>
     <!-- JavaFX UI -->
     <dependency>
       <groupId>org.openjfx</groupId>
+      <artifactId>javafx-base</artifactId>
+      <version>${javafx.version}</version>
+      <classifier>${javafx.platform}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-graphics</artifactId>
+      <version>${javafx.version}</version>
+      <classifier>${javafx.platform}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.openjfx</groupId>
       <artifactId>javafx-controls</artifactId>
       <version>${javafx.version}</version>
+      <classifier>${javafx.platform}</classifier>
     </dependency>
     <dependency>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-fxml</artifactId>
       <version>${javafx.version}</version>
+      <classifier>${javafx.platform}</classifier>
     </dependency>
 
     <!-- SQLite JDBC driver -->
@@ -51,6 +68,7 @@
 
   <build>
     <plugins>
+      <!-- JavaFX plugin to run the app -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -62,11 +80,69 @@
       <plugin>
         <groupId>org.openjfx</groupId>
         <artifactId>javafx-maven-plugin</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <configuration>
           <mainClass>com.restaurant.pos.MainApp</mainClass>
+          <launcher>pos</launcher>
+          <modules>
+            <module>javafx.controls</module>
+            <module>javafx.fxml</module>
+          </modules>
         </configuration>
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <!-- Linux AArch64 -->
+    <profile>
+      <id>linux-aarch64</id>
+      <activation>
+        <os name="Linux" arch="aarch64"/>
+      </activation>
+      <properties>
+        <javafx.platform>linux-aarch64</javafx.platform>
+      </properties>
+    </profile>
+    <!-- macOS AArch64 (Apple Silicon) -->
+    <profile>
+      <id>mac-aarch64</id>
+      <activation>
+        <os family="mac" arch="aarch64"/>
+      </activation>
+      <properties>
+        <javafx.platform>mac-aarch64</javafx.platform>
+      </properties>
+    </profile>
+    <!-- macOS x86_64 -->
+    <profile>
+      <id>mac</id>
+      <activation>
+        <os family="mac" arch="x86_64"/>
+      </activation>
+      <properties>
+        <javafx.platform>mac</javafx.platform>
+      </properties>
+    </profile>
+    <!-- Windows AArch64 -->
+    <profile>
+      <id>win-aarch64</id>
+      <activation>
+        <os family="windows" arch="aarch64"/>
+      </activation>
+      <properties>
+        <javafx.platform>win-aarch64</javafx.platform>
+      </properties>
+    </profile>
+    <!-- Windows x86_64 -->
+    <profile>
+      <id>win</id>
+      <activation>
+        <os family="windows" arch="x86_64"/>
+      </activation>
+      <properties>
+        <javafx.platform>win</javafx.platform>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
     <javafx.version>25.0.1</javafx.version>
     <slf4j.version>2.0.13</slf4j.version>
     <sqlite.jdbc.version>3.46.0.0</sqlite.jdbc.version>
-    <!-- Resolve platform-specific JavaFX native artifacts; default for Linux x86_64 -->
-    <javafx.platform>linux</javafx.platform>
+    <!-- Resolve platform-specific JavaFX native artifacts; default for Windows x86_64 -->
+    <javafx.platform>win</javafx.platform>
   </properties>
 
   <dependencies>
@@ -94,36 +94,6 @@
   </build>
 
   <profiles>
-    <!-- Linux AArch64 -->
-    <profile>
-      <id>linux-aarch64</id>
-      <activation>
-        <os name="Linux" arch="aarch64"/>
-      </activation>
-      <properties>
-        <javafx.platform>linux-aarch64</javafx.platform>
-      </properties>
-    </profile>
-    <!-- macOS AArch64 (Apple Silicon) -->
-    <profile>
-      <id>mac-aarch64</id>
-      <activation>
-        <os family="mac" arch="aarch64"/>
-      </activation>
-      <properties>
-        <javafx.platform>mac-aarch64</javafx.platform>
-      </properties>
-    </profile>
-    <!-- macOS x86_64 -->
-    <profile>
-      <id>mac</id>
-      <activation>
-        <os family="mac" arch="x86_64"/>
-      </activation>
-      <properties>
-        <javafx.platform>mac</javafx.platform>
-      </properties>
-    </profile>
     <!-- Windows AArch64 -->
     <profile>
       <id>win-aarch64</id>
@@ -132,16 +102,6 @@
       </activation>
       <properties>
         <javafx.platform>win-aarch64</javafx.platform>
-      </properties>
-    </profile>
-    <!-- Windows x86_64 -->
-    <profile>
-      <id>win</id>
-      <activation>
-        <os family="windows" arch="x86_64"/>
-      </activation>
-      <properties>
-        <javafx.platform>win</javafx.platform>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Update project to JDK 25 and JavaFX 25 with platform-specific native library support to resolve runtime errors.

The previous configuration led to runtime errors such as "javafx/application/Application not found" or "no javafx_graphics in java.library.path" due to missing platform-specific JavaFX native artifacts. This update explicitly includes these artifacts via Maven profiles and updates the JavaFX Maven plugin configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9fe24b0-329b-404e-a3c1-d2718d83993f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e9fe24b0-329b-404e-a3c1-d2718d83993f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

